### PR TITLE
Add try-catch around JSON deserialization

### DIFF
--- a/src/Endzone.uSplit/Models/Experiment.cs
+++ b/src/Endzone.uSplit/Models/Experiment.cs
@@ -64,18 +64,19 @@ namespace Endzone.uSplit.Models
             var source = description ?? string.Empty;
             var separatorPosition = source.IndexOf(DescriptionSeparator, StringComparison.InvariantCultureIgnoreCase);
             if (separatorPosition > -1)
+            {
                 source = source.Substring(separatorPosition);
-
-            ExperimentConfiguration settings = null;
-            try
-            {
-                settings = JsonConvert.DeserializeObject<ExperimentConfiguration>(source);
+                try
+                {
+                    var settings = JsonConvert.DeserializeObject<ExperimentConfiguration>(source);
+                    return settings ?? new ExperimentConfiguration();
+                }
+                catch (JsonReaderException e)
+                {
+                    LogHelper.Error<Experiment>("Parsing segmentation settings for experiment failed. Will use default settings.", e);
+                }
             }
-            catch (JsonReaderException e)
-            {
-                LogHelper.Error<Experiment>("Parsing segmentation settings failed. Will use default settings.", e);
-            }
-            return settings ?? new ExperimentConfiguration();
+            return new ExperimentConfiguration();
         }
 
         public static string UpdateSettings(string description, ExperimentConfiguration settings)

--- a/src/Endzone.uSplit/Models/Experiment.cs
+++ b/src/Endzone.uSplit/Models/Experiment.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using Newtonsoft.Json;
 using Umbraco.Core;
+using Umbraco.Core.Logging;
 using Umbraco.Core.Models;
 using GoogleExperiment = Google.Apis.Analytics.v3.Data.Experiment;
 
@@ -64,7 +65,17 @@ namespace Endzone.uSplit.Models
             var separatorPosition = source.IndexOf(DescriptionSeparator, StringComparison.InvariantCultureIgnoreCase);
             if (separatorPosition > -1)
                 source = source.Substring(separatorPosition);
-            return JsonConvert.DeserializeObject<ExperimentConfiguration>(source) ?? new ExperimentConfiguration();
+
+            ExperimentConfiguration settings = null;
+            try
+            {
+                settings = JsonConvert.DeserializeObject<ExperimentConfiguration>(source);
+            }
+            catch (JsonReaderException e)
+            {
+                LogHelper.Error<Experiment>("Parsing segmentation settings failed. Will use default settings.", e);
+            }
+            return settings ?? new ExperimentConfiguration();
         }
 
         public static string UpdateSettings(string description, ExperimentConfiguration settings)


### PR DESCRIPTION
Fixes issue #15 

The problem was not UTF8 after all. Instead the problem was that uSplit would always treat the experiment description as a json string.

This commit only wraps the deserialization in a try-catch clause and logs the exception.

A better fix would be to only deserialize the description when it contains the description separator. That would be a breaking change, however.