### PR TITLE
Fix for #22, Custom models can't be used with uSplit

### DIFF
--- a/src/Endzone.uSplit/HtmlHelperExtensions.cs
+++ b/src/Endzone.uSplit/HtmlHelperExtensions.cs
@@ -2,6 +2,7 @@
 using System.Web.Mvc;
 using Endzone.uSplit.GoogleApi;
 using Endzone.uSplit.Models;
+using Umbraco.Web.Routing;
 
 namespace Endzone.uSplit
 {
@@ -22,9 +23,10 @@ namespace Endzone.uSplit
 
                 var umbracoContext = helper.ViewContext.HttpContext.GetUmbracoContext();
                 var request = umbracoContext.PublishedContentRequest;
-
-                return request?.PublishedContent as VariedContent;
+                return request?.InitialPublishedContent as VariedContent;
             }
+
+
 
             /// <summary>
             /// Renders a series of analytics.js JavaScript method calls that report the

--- a/src/Endzone.uSplit/Pipeline/ExperimentsPipeline.cs
+++ b/src/Endzone.uSplit/Pipeline/ExperimentsPipeline.cs
@@ -8,6 +8,7 @@ using Endzone.uSplit.Models;
 using Umbraco.Core;
 using Umbraco.Core.Logging;
 using Umbraco.Core.Models;
+using Umbraco.Core.Models.PublishedContent;
 using Umbraco.Web;
 using Umbraco.Web.Routing;
 using Experiment = Endzone.uSplit.Models.Experiment;
@@ -108,6 +109,11 @@ namespace Endzone.uSplit.Pipeline
 
             var variedContent = new VariedContent(request.PublishedContent, variationsToApply.ToArray());
             request.PublishedContent = variedContent;
+            request.SetIsInitialPublishedContent();
+
+            //Reset the published content now we have set the initial content
+            request.PublishedContent = PublishedContentModelFactoryResolver.Current.Factory.CreateModel(variedContent);
+
             request.TrySetTemplate(variedContent.GetTemplateAlias());
         }
 


### PR DESCRIPTION
Hi,

This fixes an issue I came across when trying out uSplit. The issue was the custom model uSplit uses seems incompatible with custom models produced by the Model Builder or mapped on custom controllers. 

In order to fix this, I have adapted the pipeline to use the current PublishedContentModelFactoryResolver to map the variant to any custom model that is associated top the content type. The variant view model is then associated too the InitialPublishedContent in order to allow the HTML helpers to pick up the correct scripts.

This seems to fix the problem on a simple test site so hopefully, it will be found useful.

Cheers,

Paul
